### PR TITLE
Allow for selection of non-convex regions

### DIFF
--- a/data/sample-options.json
+++ b/data/sample-options.json
@@ -1,0 +1,3 @@
+{
+    "hullAlgorithm": "concave"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ var Visualization = ImageViz.extend({
 
         // set free drawing options
         freeDraw.options.attemptMerge = false;
-        freeDraw.options.setHullAlgorithm('brian3kb/graham_scan_js');
+        freeDraw.options.setHullAlgorithm(false);
         freeDraw.options.setSmoothFactor(0);
         
         // add the free drawing layer

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ var Visualization = ImageViz.extend({
 
         // set free drawing options
         freeDraw.options.attemptMerge = false;
-        freeDraw.options.setHullAlgorithm(false);
+        freeDraw.options.setHullAlgorithm('Wildhoney/ConcaveHull');
         freeDraw.options.setSmoothFactor(0);
         
         // add the free drawing layer

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,11 @@ var fs = require('fs');
 var css = fs.readFileSync(__dirname + '/style.css');
 var template = _.template(fs.readFileSync(__dirname + '/templates/index.html'));
 
+var hullAlgMap = {
+    concave: 'Wildhoney/ConcaveHull',
+    convex: 'brian3kb/graham_scan_js'
+}
+
 /*
  * Extend the base visualization object
  */
@@ -28,6 +33,12 @@ var Visualization = ImageViz.extend({
         this.$el = $(this.selector).first();
         this.$el.append(markup);
         this.render();
+    },
+
+    getDefaultOptions: function() {
+        return {
+            hullAlgorithm: 'concave'
+        }
     },
 
     render: function() {
@@ -57,7 +68,7 @@ var Visualization = ImageViz.extend({
 
         //create the map
         if(this.map) {
-            this.map.remove();    
+            this.map.remove();
         }
         this.map = L.map('image-map-' + this.identifier, {
             minZoom: 1,
@@ -68,18 +79,18 @@ var Visualization = ImageViz.extend({
             zoomControl: false,
             crs: L.CRS.Simple,
         });
-        
+
         var map = this.map;
-             
+
         // calculate the edges of the image, in coordinate space
         var southWest = map.unproject([0, h], 1);
         var northEast = map.unproject([w, 0], 1);
         var bounds = new L.LatLngBounds(southWest, northEast);
-         
+
         // add the image overlay to cover the map
         var overlay = L.imageOverlay(img.src, bounds);
         map.addLayer(overlay)
-         
+
         // tell leaflet that the map is exactly as big as the image
         map.setMaxBounds(bounds);
 
@@ -90,9 +101,9 @@ var Visualization = ImageViz.extend({
 
         // set free drawing options
         freeDraw.options.attemptMerge = false;
-        freeDraw.options.setHullAlgorithm('Wildhoney/ConcaveHull');
+        freeDraw.options.setHullAlgorithm(hullAlgMap[this.options.hullAlgorithm]);
         freeDraw.options.setSmoothFactor(0);
-        
+
         // add the free drawing layer
         map.addLayer(freeDraw);
 
@@ -162,7 +173,7 @@ var Visualization = ImageViz.extend({
                     fill = c;
                 }
                 return fill.brighter(1.2).toString();
-               }); 
+               });
 
         }
 
@@ -231,14 +242,14 @@ var Visualization = ImageViz.extend({
                 coords = settings.coords;
             }
         });
-        
+
         freeDraw.on('markers', updateStyles);
         freeDraw.on('destroy', function(d) {
 
             var i = d.index;
-            
+
             if(data.color && _.isArray(data.color)) {
-                data.color.splice(i, 1);    
+                data.color.splice(i, 1);
 
                 if(data.color.length === 0) {
                     colorIndex = 0;
@@ -249,7 +260,7 @@ var Visualization = ImageViz.extend({
             getUserData()
             updateStyles()
         })
-        
+
         this.map = map
         this.bounds = bounds
         this.overlay = overlay
@@ -257,7 +268,7 @@ var Visualization = ImageViz.extend({
 
     formatData: function(data) {
         if (!_.isEmpty(data)) {
-            
+
             var polygons = []
 
             if (validator.isFeatureCollection(data)) {
@@ -295,11 +306,11 @@ var Visualization = ImageViz.extend({
         */
     },
 
-    appendData: function(formattedData) {    
+    appendData: function(formattedData) {
         /*
         // FILL IN Update this.data to include the newly formatted data
         // FILL IN Re-render the visualization
-        */    
+        */
     }
 
 });


### PR DESCRIPTION
After selecting a polygon, the polygon is normalized to a convex hull. This is not a desired behavior when selecting an irregular region of interest. This PR replaces the convex hull normalization with a concave hull.
